### PR TITLE
allow application config of api_key/secret

### DIFF
--- a/lib/config.ex
+++ b/lib/config.ex
@@ -7,12 +7,12 @@ defmodule ExNexmo.Config do
   @doc """
   Gets the Nexmo API key from an environment variable.
   """
-  def api_key, do: System.get_env("NEXMO_API_KEY")
+  def api_key, do: Application.get_env(:ex_nexmo, :api_key, System.get_env("NEXMO_API_KEY"))
 
   @doc """
   Gets the Nexmo API secret from an environment variable.
   """
-  def api_secret, do: System.get_env("NEXMO_API_SECRET")
+  def api_secret, do: Application.get_env(:ex_nexmo, :api_secret, System.get_env("NEXMO_API_SECRET"))
 
   @doc """
   Gets the Nexmo API host from the application config.


### PR DESCRIPTION
not everybody uses system env in elixir world - including for various deployment strategies, and dev environments.

this allows setting :api_key, and :api_secret in the application config in whatever way you want - though keeping backward compatibility, by falling back to system env.